### PR TITLE
Fix memory aligned access for arm based cpus

### DIFF
--- a/cj5.h
+++ b/cj5.h
@@ -427,7 +427,12 @@ found:
         type = CJ5_TOKEN_STRING;
     } else {
         // detect other types, subtypes
+#if __arm__
+        uint32_t fourcc_ = (uint32_t)json5[start];
+        uint32_t* fourcc = &fourcc_;
+#else
         uint32_t* fourcc = (uint32_t*)&json5[start];
+#endif
         if (*fourcc == CJ5__NULL_FOURCC) {
             type = CJ5_TOKEN_NULL;
         } else if (*fourcc == CJ5__TRUE_FOURCC) {
@@ -1216,6 +1221,7 @@ int cj5_get_array_elem_incremental(cj5_result* r, int id, int index, int prev_el
     }
     return -1;
 }
+
 
 #    endif    // CJ5_TOKEN_HELPERS
 #endif        // CJ5_IMPLEMENT


### PR DESCRIPTION
Especially in ARM Cortex-M devices a memory unaligned access
can result in a hard fault error