### PR TITLE
Fix memory aligned access for arm based cpus

### DIFF
--- a/cj5.h
+++ b/cj5.h
@@ -429,7 +429,7 @@ found:
         // detect other types, subtypes
 #if __arm__
         uint32_t fourcc_ = (uint32_t)json5[start];
-        memcpy(&fourcc_, &json5[start], 4);
+        CJ5_MEMCPY(&fourcc_, &json5[start], 4);
         uint32_t* fourcc = &fourcc_;
 #else
         uint32_t* fourcc = (uint32_t*)&json5[start];

--- a/cj5.h
+++ b/cj5.h
@@ -141,6 +141,7 @@ CJ5_API cj5_result cj5_parse(const char* json5, int len, cj5_token* tokens, int 
 // token helpers
 #if CJ5_TOKEN_HELPERS
 CJ5_API int cj5_seek(cj5_result* r, int parent_id, const char* key);
+CJ5_API int cj5_seek_hash(cj5_result* r, int parent_id, const uint32_t key_hash);
 CJ5_API int cj5_seek_recursive(cj5_result* r, int parent_id, const char* key);
 CJ5_API const char* cj5_get_string(cj5_result* r, int id, char* str, int max_str);
 CJ5_API double cj5_get_double(cj5_result* r, int id);
@@ -849,11 +850,9 @@ int cj5_seek_recursive(cj5_result* r, int parent_id, const char* key)
     return cj5__seek_recursive(r, parent_id, key_hash);
 }
 
-int cj5_seek(cj5_result* r, int parent_id, const char* key)
+int cj5_seek_hash(cj5_result* r, int parent_id, const uint32_t key_hash)
 {
     CJ5_ASSERT(parent_id >= 0 && parent_id < r->num_tokens);
-
-    uint32_t key_hash = cj5__hash_fnv32(key, key + cj5__strlen(key));
     const cj5_token* parent_tok = &r->tokens[parent_id];
 
     for (int i = parent_id + 1, count = 0; i < r->num_tokens && count < parent_tok->size; i++) {
@@ -873,6 +872,15 @@ int cj5_seek(cj5_result* r, int parent_id, const char* key)
     }
 
     return -1;
+}
+
+int cj5_seek(cj5_result* r, int parent_id, const char* key)
+{
+    CJ5_ASSERT(parent_id >= 0 && parent_id < r->num_tokens);
+
+    uint32_t key_hash = cj5__hash_fnv32(key, key + cj5__strlen(key));
+
+    return cj5_seek_hash(r, parent_id, key_hash);
 }
 
 const char* cj5_get_string(cj5_result* r, int id, char* str, int max_str)

--- a/cj5.h
+++ b/cj5.h
@@ -427,7 +427,13 @@ found:
         type = CJ5_TOKEN_STRING;
     } else {
         // detect other types, subtypes
+#if __arm__
+        uint32_t fourcc_ = (uint32_t)json5[start];
+        memcpy(&fourcc_, &json5[start], 4);
+        uint32_t* fourcc = &fourcc_;
+#else
         uint32_t* fourcc = (uint32_t*)&json5[start];
+#endif
         if (*fourcc == CJ5__NULL_FOURCC) {
             type = CJ5_TOKEN_NULL;
         } else if (*fourcc == CJ5__TRUE_FOURCC) {


### PR DESCRIPTION
Especially in ARM Cortex-M devices a memory unaligned access
can result in a hard fault error. 